### PR TITLE
Command tools

### DIFF
--- a/README-zh_CN.md
+++ b/README-zh_CN.md
@@ -15,6 +15,7 @@
 ## 目录
 
 - [截图](#截图)
+- [命令行工具](#命令行工具)
 - [安装](#安装)
   - [下载](#下载)
 - [开发和构建](#开发和构建)
@@ -29,6 +30,56 @@
 
 <img width="1060" alt="image" src="https://github.com/1111mp/nvm-desktop/assets/31227919/45f4c613-2d17-4804-bc83-ac07260bc6c0">
 <img width="1048" alt="image" src="https://github.com/1111mp/nvm-desktop/assets/31227919/757525bc-489d-4611-b957-c780fa9bfab5">
+
+## 命令行工具
+
+您可以直接在终端中输入命令行管理所有 Node 版本。 `nvmd` 不提供 Node 的下载安装功能，如果您需要下载安装新版本的 Node，请打开 `nvm-desktop` 客户端。
+
+`nvmd` 允许您通过命令行快速管理不同版本的 Node：
+
+```shell
+$ nvmd use 18.17.1
+Now using node v18.17.1
+$ node -v
+v18.17.1
+$ nvmd use v20.5.1 --project
+Now using node v20.5.1
+$ node -v
+v20.5.1
+$ nvmd ls
+v20.6.1
+v20.5.1 (currently)
+v18.17.1
+$ nvmd current
+v20.5.1
+```
+
+`nvmd --help`：
+
+```shell
+$ nvmd --help
+nvmd (2.2.0)
+The1111mp@outlook.com
+command tools for nvm-desktop
+
+Usage: nvmd [COMMAND]
+
+Commands:
+  current  Get the currently used version
+  list     List the all installed versions of Node.js
+  ls       List the all installed versions of Node.js
+  use      Use the installed version of Node.js (default is global)
+  which    Get the path to the executable to where Node.js was installed
+  help     Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help     Print help
+  -V, --version  Print version
+
+Please download new version of Node.js in nvm-desktop.
+```
+
+更多详情请查看此文档: [command-tools-intro](https://github.com/1111mp/nvmd-command#command-tools-intro) .
 
 ## 安装
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ English | [简体中文](https://github.com/1111mp/nvm-desktop/blob/main/README-
 ## Table of Contents
 
 - [Screenshot](#screenshot)
+- [Command toos intro](#command-toos-intro)
 - [Install](#install)
   - [Download](#download)
 - [Develop and Build](#develop-and-build)
@@ -29,6 +30,56 @@ English | [简体中文](https://github.com/1111mp/nvm-desktop/blob/main/README-
 
 <img width="1060" alt="image" src="https://github.com/1111mp/nvm-desktop/assets/31227919/45f4c613-2d17-4804-bc83-ac07260bc6c0">
 <img width="1048" alt="image" src="https://github.com/1111mp/nvm-desktop/assets/31227919/757525bc-489d-4611-b957-c780fa9bfab5">
+
+## Command toos intro
+
+You can also manage all versions of node directly from the command line. The `nvmd` does not provide the node download and installation functions. If you need to download and install a new version of node, you should open the `nvm-desktop` application.
+
+`nvmd` allows you to quickly manage different versions of node via the command line.
+
+```shell
+$ nvmd use 18.17.1
+Now using node v18.17.1
+$ node -v
+v18.17.1
+$ nvmd use v20.5.1 --project
+Now using node v20.5.1
+$ node -v
+v20.5.1
+$ nvmd ls
+v20.6.1
+v20.5.1 (currently)
+v18.17.1
+$ nvmd current
+v20.5.1
+```
+
+`nvmd --help`:
+
+```shell
+$ nvmd --help
+nvmd (2.2.0)
+The1111mp@outlook.com
+command tools for nvm-desktop
+
+Usage: nvmd [COMMAND]
+
+Commands:
+  current  Get the currently used version
+  list     List the all installed versions of Node.js
+  ls       List the all installed versions of Node.js
+  use      Use the installed version of Node.js (default is global)
+  which    Get the path to the executable to where Node.js was installed
+  help     Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help     Print help
+  -V, --version  Print version
+
+Please download new version of Node.js in nvm-desktop.
+```
+
+For more details, please check document: [command-tools-intro](https://github.com/1111mp/nvmd-command#command-tools-intro) .
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ If you are using `VS Code` and launch your project with `Debug`, then you should
 ## Features
 
 - [x] Supports setting the Node engine version separately for the project.
+- [x] Command tools for manage the version of Node.
 - [x] Support English & Simplified Chinese
 - [x] Support for custom download mirrors (default is https://nodejs.org/dist)
 - [x] Support automatic update on Windows.

--- a/src/main/deps/all-node-versions/cache/index.ts
+++ b/src/main/deps/all-node-versions/cache/index.ts
@@ -40,15 +40,20 @@ export async function getCache({
 export async function getInstalledVersions(): Promise<string[]> {
   if (!(await pathExists(INSTALL_DIR))) return [];
 
-  const versions = (await readdir(INSTALL_DIR)).filter(async (version) => {
-    const node = join(
-      INSTALL_DIR,
-      version,
-      platform === 'win32' ? 'node.exe' : 'bin/node',
-    );
+  const contents = await readdir(INSTALL_DIR);
+  const exists = await Promise.all(
+    contents.map(async (version) => {
+      return await pathExists(
+        join(
+          INSTALL_DIR,
+          version,
+          platform === 'win32' ? 'node.exe' : 'bin/node',
+        ),
+      );
+    }),
+  );
 
-    return await pathExists(node);
-  });
+  const versions = contents.filter((_, index) => exists[index]);
 
   return versions;
 }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -239,7 +239,7 @@ app
 
 function createTray() {
   if (tray) return;
-  
+
   const iconName =
     platform === 'win32'
       ? join('windows', 'icon.png')
@@ -447,8 +447,8 @@ Promise.resolve().then(() => {
     },
   );
 
-  ipcMain.handle('current-version', async () => {
-    const version = getCurrentVersion();
+  ipcMain.handle('current-version', async (_event, fetch: boolean = false) => {
+    const version = getCurrentVersion(fetch);
 
     return version;
   });

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -107,7 +107,8 @@ const electronHandler = {
 
   useNodeVersion: (version: string) =>
     ipcRenderer.invoke('use-version', version),
-  getCurrentVersion: () => ipcRenderer.invoke('current-version'),
+  getCurrentVersion: (fetch: boolean = false) =>
+    ipcRenderer.invoke('current-version', fetch),
   onRegistCurVersionChange: (callback: OnCurVersionChange) => {
     onCurVersionChange = callback;
   },

--- a/src/renderer/pages/installed/index.tsx
+++ b/src/renderer/pages/installed/index.tsx
@@ -248,15 +248,17 @@ export const Component: React.FC = () => {
   const onRefresh = async () => {
     setLoading(true);
     try {
-      const [versions, installeds] = await Promise.all([
+      const [versions, installeds, currentVersion] = await Promise.all([
         window.Context.getAllNodeVersions(),
         window.Context.getInstalledNodeVersions(),
+        window.Context.getCurrentVersion(true),
       ]);
-      message.success('Refresh successed');
       setVersions(
         versions.filter(({ version }) => installeds.includes(version.slice(1))),
       );
       setInstalledVersions(installeds);
+      setCurrent(currentVersion);
+      message.success('Refresh successed');
     } catch (err) {
     } finally {
       setLoading(false);

--- a/src/renderer/pages/versions/index.tsx
+++ b/src/renderer/pages/versions/index.tsx
@@ -83,7 +83,7 @@ export const Versions: React.FC = () => {
         render: (text: string, { lts, version }) => {
           return (
             <Space>
-              <Tooltip color="#74a975" title={i18n("Whats-new")}>
+              <Tooltip color="#74a975" title={i18n('Whats-new')}>
                 <span
                   className="module-versions-label__link"
                   onClick={() => {
@@ -291,13 +291,15 @@ export const Versions: React.FC = () => {
   const onLocalRefresh = async () => {
     seLocaltLoading(true);
     try {
-      const [versions, installeds] = await Promise.all([
+      const [versions, installeds, currentVersion] = await Promise.all([
         window.Context.getAllNodeVersions(),
         window.Context.getInstalledNodeVersions(),
+        window.Context.getCurrentVersion(true),
       ]);
-      message.success('Refresh successed');
       setVersions(versions);
       setInstalledVersions(installeds);
+      setCurrent(currentVersion);
+      message.success('Refresh successed');
     } catch (err) {
     } finally {
       seLocaltLoading(false);
@@ -307,15 +309,17 @@ export const Versions: React.FC = () => {
   const onRemoteRefresh = async () => {
     setLoading(true);
     try {
-      const [versions, installeds] = await Promise.all([
+      const [versions, installeds, currentVersion] = await Promise.all([
         window.Context.getAllNodeVersions({
           fetch: true,
         }),
         window.Context.getInstalledNodeVersions(true),
+        window.Context.getCurrentVersion(true),
       ]);
-      message.success('Refresh successed');
       setVersions(versions);
       setInstalledVersions(installeds);
+      setCurrent(currentVersion);
+      message.success('Refresh successed');
     } catch (err) {
       message.error(
         err.message


### PR DESCRIPTION
## Features

- Support Command tools: manage the version of Node via the command line.

```shell
$ nvmd --help
nvmd (2.2.0)
The1111mp@outlook.com
command tools for nvm-desktop

Usage: nvmd [COMMAND]

Commands:
  current  Get the currently used version
  list     List the all installed versions of Node.js
  ls       List the all installed versions of Node.js
  use      Use the installed version of Node.js (default is global)
  which    Get the path to the executable to where Node.js was installed
  help     Print this message or the help of the given subcommand(s)

Options:
  -h, --help     Print help
  -V, --version  Print version

Please download new version of Node.js in nvm-desktop.
```

## Fixes

- System tray menu duplicate creation.
- Get invalid node version causes the application to crash.
