### PR TITLE
fix: 'arch' option was not taking effect during installation

### DIFF
--- a/src/pages/versions/modal.tsx
+++ b/src/pages/versions/modal.tsx
@@ -115,7 +115,7 @@ export const Modal = forwardRef<Ref, Props>(({ onRefrresh }, ref) => {
 		setPath(undefined);
 		progress.current = undefined;
 		try {
-			const path = await installNode(record.current!.version.slice(1));
+			const path = await installNode(record.current!.version.slice(1), arch.current!.innerText);
 
 			progress.current = {
 				...progress.current!,


### PR DESCRIPTION
The ```installNode``` method supports the arch parameter, but the arch parameter is not passed in during modal.tsx installation.