### PR TITLE
Fix Node extraction rename handling on Windows

### DIFF
--- a/src-tauri/crates/get-node/src/archive/mod.rs
+++ b/src-tauri/crates/get-node/src/archive/mod.rs
@@ -11,7 +11,7 @@ use std::{
     time::{Duration, SystemTime},
 };
 use tokio::{
-    fs::{File, OpenOptions},
+    fs::{metadata, remove_dir_all, remove_file, rename, File, OpenOptions},
     io::{AsyncReadExt, AsyncWriteExt},
 };
 
@@ -25,6 +25,47 @@ const DOWNLOAD_MAX_RETRIES: usize = 3;
 const DOWNLOAD_RETRY_DELAY_MS: u64 = 800;
 const NODE_SHASUMS_FILE: &str = "SHASUMS256.txt";
 const STALE_PARTIAL_MAX_AGE: Duration = Duration::from_secs(60 * 60 * 24 * 7);
+
+pub(super) async fn finalize_extraction(
+    extracted_dir: &Path,
+    version_dir: &Path,
+    archive_path: &Path,
+) -> Result<String> {
+    if metadata(version_dir).await.is_ok() {
+        let _ = remove_dir_all(extracted_dir).await;
+        let _ = remove_file(archive_path).await;
+        return Ok(version_dir.to_string_lossy().to_string());
+    }
+
+    let mut last_error = None;
+    for attempt in 0..5 {
+        match rename(extracted_dir, version_dir).await {
+            Ok(_) => {
+                let _ = remove_file(archive_path).await;
+                return Ok(version_dir.to_string_lossy().to_string());
+            }
+            Err(err) => {
+                if metadata(version_dir).await.is_ok() {
+                    let _ = remove_dir_all(extracted_dir).await;
+                    let _ = remove_file(archive_path).await;
+                    return Ok(version_dir.to_string_lossy().to_string());
+                }
+
+                last_error = Some(err);
+                if attempt < 4 {
+                    tokio::time::sleep(Duration::from_millis(200)).await;
+                }
+            }
+        }
+    }
+
+    let err = last_error.expect("rename should have been attempted");
+    anyhow::bail!(
+        "Failed to rename extracted Node.js directory from '{}' to '{}': {err}",
+        extracted_dir.display(),
+        version_dir.display()
+    );
+}
 
 pub struct FetchConfig {
     /// output dir

--- a/src-tauri/crates/get-node/src/archive/tarball.rs
+++ b/src-tauri/crates/get-node/src/archive/tarball.rs
@@ -4,14 +4,14 @@ use futures_util::StreamExt;
 use node_semver::Version;
 use std::{path::PathBuf, time::Duration};
 use tokio::{
-    fs::{remove_dir_all, remove_file, rename, File},
+    fs::{remove_dir_all, File},
     io::BufReader,
 };
 use tokio_tar::ArchiveBuilder;
 
 use super::{
     cleanup_stale_partial_archives, create_client, download_archive, ensure_not_cancelled,
-    get_temp_archive_path, node::*, verify_archive_checksum, FetchConfig,
+    finalize_extraction, get_temp_archive_path, node::*, verify_archive_checksum, FetchConfig,
 };
 
 pub async fn fetch(config: FetchConfig) -> Result<String> {
@@ -104,11 +104,5 @@ pub async fn fetch(config: FetchConfig) -> Result<String> {
         on_progress("unzip", unpacked_size as usize, unpacked_size as usize);
     }
 
-    let (_rename_future, _remove_future) = tokio::join!(
-        rename(dest.join(&name), dest.join(&version)),
-        remove_file(temp_file_path)
-    );
-
-    let path = dest.join(&version).to_string_lossy().to_string();
-    Ok(path)
+    finalize_extraction(&dest.join(&name), &dest.join(&version), &temp_file_path).await
 }

--- a/src-tauri/crates/get-node/src/archive/zip.rs
+++ b/src-tauri/crates/get-node/src/archive/zip.rs
@@ -7,14 +7,14 @@ use anyhow::{anyhow, bail, Result};
 use async_zip::base::read::seek::ZipFileReader;
 use node_semver::Version;
 use tokio::{
-    fs::{create_dir_all, remove_dir_all, remove_file, rename, File, OpenOptions},
+    fs::{create_dir_all, remove_dir_all, File, OpenOptions},
     io::BufReader,
 };
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
 use super::{
     cleanup_stale_partial_archives, create_client, download_archive, ensure_not_cancelled,
-    get_temp_archive_path, node::*, verify_archive_checksum, FetchConfig,
+    finalize_extraction, get_temp_archive_path, node::*, verify_archive_checksum, FetchConfig,
 };
 
 fn resolve_entry_path(dest: &Path, entry_name: &str) -> Result<PathBuf> {
@@ -140,11 +140,5 @@ pub async fn fetch(config: FetchConfig) -> Result<String> {
         bail!("Unzipping was cancelled");
     }
 
-    let (_rename_future, _remove_future) = tokio::join!(
-        rename(dest.join(&name), dest.join(&version)),
-        remove_file(temp_file_path)
-    );
-
-    let path = dest.join(&version).to_string_lossy().to_string();
-    Ok(path)
+    finalize_extraction(&dest.join(&name), &dest.join(&version), &temp_file_path).await
 }


### PR DESCRIPTION
Fix #305 

### Motivation
- Address a reported Windows issue where extraction succeeded but the rename to the plain version directory failed, leaving a folder named like `node-v24.18.0-win-x64` that the app could not recognize. 

### Description
- Add a shared helper `finalize_extraction` in `src-tauri/crates/get-node/src/archive/mod.rs` that retries renaming the extracted `node-v...` directory to the target version directory, cleans up the temp archive file, and surfaces a clear error on persistent failure. 
- Treat an already-existing `version_dir` as success by removing the extracted directory and archive, then returning the `version_dir` path. 
- Replace direct `rename` calls in `src-tauri/crates/get-node/src/archive/zip.rs` and `src-tauri/crates/get-node/src/archive/tarball.rs` with calls to `finalize_extraction` so both zip and tarball paths share the improved behavior. 
- Retry the rename up to 5 times with short sleeps between attempts and include an informative error message if all attempts fail. 

### Testing
- Ran `cargo test --manifest-path src-tauri/crates/get-node/Cargo.toml` but it failed to fetch crates from crates.io due to a network `CONNECT tunnel failed, response 403` error. 
- Ran `cargo test --manifest-path src-tauri/crates/get-node/Cargo.toml --offline` and the unit tests completed successfully with `5 passed; 0 failed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3df012cfa0832aa8a22ef5e391d3bd)