### PR TITLE
Fix Windows Node extraction rename

### DIFF
--- a/src-tauri/crates/get-node/src/archive/tarball.rs
+++ b/src-tauri/crates/get-node/src/archive/tarball.rs
@@ -104,5 +104,8 @@ pub async fn fetch(config: FetchConfig) -> Result<String> {
         on_progress("unzip", unpacked_size as usize, unpacked_size as usize);
     }
 
+    drop(entries);
+    drop(tarball);
+
     finalize_extraction(&dest.join(&name), &dest.join(&version), &temp_file_path).await
 }

--- a/src-tauri/crates/get-node/src/archive/zip.rs
+++ b/src-tauri/crates/get-node/src/archive/zip.rs
@@ -11,6 +11,7 @@ use tokio::{
     io::BufReader,
 };
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
+use futures_lite::AsyncWriteExt;
 
 use super::{
     cleanup_stale_partial_archives, create_client, download_archive, ensure_not_cancelled,
@@ -129,7 +130,9 @@ pub async fn fetch(config: FetchConfig) -> Result<String> {
                 .create_new(true)
                 .open(&path)
                 .await?;
-            futures_lite::io::copy(&mut entry_reader, &mut writer.compat_write()).await?;
+            let mut writer = writer.compat_write();
+            futures_lite::io::copy(&mut entry_reader, &mut writer).await?;
+            writer.close().await?;
         }
 
         on_progress("unzip", index + 1, total_entries);
@@ -139,6 +142,8 @@ pub async fn fetch(config: FetchConfig) -> Result<String> {
         let _ = remove_dir_all(dest.join(&name)).await;
         bail!("Unzipping was cancelled");
     }
+
+    drop(reader);
 
     finalize_extraction(&dest.join(&name), &dest.join(&version), &temp_file_path).await
 }

--- a/src-tauri/crates/get-node/src/archive/zip.rs
+++ b/src-tauri/crates/get-node/src/archive/zip.rs
@@ -5,13 +5,13 @@ use std::{
 
 use anyhow::{anyhow, bail, Result};
 use async_zip::base::read::seek::ZipFileReader;
+use futures_lite::AsyncWriteExt;
 use node_semver::Version;
 use tokio::{
     fs::{create_dir_all, remove_dir_all, File, OpenOptions},
     io::BufReader,
 };
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
-use futures_lite::AsyncWriteExt;
 
 use super::{
     cleanup_stale_partial_archives, create_client, download_archive, ensure_not_cancelled,


### PR DESCRIPTION
### Motivation
- Windows can fail to rename the extracted Node directory (resulting in names like `node-v24.18.0-win-x64`) because file handles held by archive writers/readers are still open when `rename` is attempted, causing `Access is denied (os error 5)` errors. 
- Ensure all per-entry writers and archive readers/iterators are closed/dropped before calling `finalize_extraction` so the rename can succeed cross-platform.

### Description
- For ZIP extraction (`src-tauri/crates/get-node/src/archive/zip.rs`) the writer is now explicitly closed after copying each entry by converting to a compat writer and calling `close().await`, and `futures_lite::AsyncWriteExt` was imported. 
- The ZIP archive reader is explicitly dropped before calling `finalize_extraction` to release any remaining handles. 
- For tarball extraction (`src-tauri/crates/get-node/src/archive/tarball.rs`) the `entries` iterator and `tarball` are explicitly dropped before `finalize_extraction` so files are not held open on Windows. 

### Testing
- Ran `cargo fmt --manifest-path src-tauri/Cargo.toml` which completed successfully. 
- Ran `cargo check --manifest-path src-tauri/Cargo.toml -p get-node` which completed successfully (with compiler warnings). 
- Ran `git diff --check` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e13e4b190832ab584ac12fba19119)